### PR TITLE
Remove unnecessary entries from seriesMappings

### DIFF
--- a/GuideEnricher/app.config
+++ b/GuideEnricher/app.config
@@ -41,8 +41,6 @@
     <seriesMap schedulesDirectName="Star Trek: Enterprise" tvdbComName="id=73893"/>
     <seriesMap schedulesDirectName="Flashpoint" tvdbComName="id=82438"/>
     <seriesMap schedulesDirectName="Dr. House" tvdbComName="id=73255"/>
-    <seriesMap schedulesDirectName="Castle" tvdbComName="" ignore="true"/>
-    <seriesMap schedulesDirectName="Monk" tvdbComName="" ignore="true"/>
   </seriesMapping>
   <!--
     You can change the priority of the match methods used for episode matching by changing the order


### PR DESCRIPTION
There were 2 shows (Castle and Monk) that were set to ignore. This sneaked in from one of my changes, and is only in there because my channels didn't have any usable info for those shows. Ignoring those will probably be the wrong way for most people.
Maybe the other mappings should also go? Not quite sure.